### PR TITLE
chore: update vite config for base github pages reponame path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,9 @@ import vue from "@vitejs/plugin-vue";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue()],
+  base: "/color-calc-vue",
   build: {
     outDir: "dist/color-calc-vue",
+    assetsDir: "assets",
   },
 });


### PR DESCRIPTION
should load color-calc-vue/assets from GitHub Pages repo site path